### PR TITLE
Update Cypress GHA to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       # only install the dependencies using
       # https://github.com/cypress-io/github-action
       - name: Install 📦
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           runTests: false
 
@@ -59,7 +59,7 @@ jobs:
 
       # reinstall dependencies and run Cypress tests
       - name: Cypress tests 🧪
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v5
         with:
           # start the local server
           start: npm run serve


### PR DESCRIPTION
This PR updates GitHub action dependency:

- from [cypress-io/github-action](https://github.com/cypress-io/github-action)@v2 to v5

to resolve the deprecation warnings:

"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: cypress-io/github-action@v2"

and

"The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"
