### PR TITLE
fix: vite port listen IPv6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "cypress-gh-action-split-jobs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-gh-action-split-jobs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "reveal.js": "4.4.0",
-        "vite": "^4.2.0"
+        "vite": "4.2.1"
       },
       "devDependencies": {
         "cypress": "9.7.0",
@@ -2556,9 +2556,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.0.tgz",
-      "integrity": "sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.2.1.tgz",
+      "integrity": "sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==",
       "dependencies": {
         "esbuild": "^0.17.5",
         "postcss": "^8.4.21",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "cypress-gh-action-split-jobs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Example with separate install and test jobs using Cypress GitHub Action",
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
+    "dev": "vite --host",
     "build": "vite build",
-    "serve": "vite preview --host 0.0.0.0",
+    "serve": "vite preview --host",
     "local": "start-test dev http-get://localhost:5173 cy:open",
     "cy:open": "cypress open",
     "cy:run": "cypress run"
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/bahmutov/cypress-gh-action-split-jobs#readme",
   "dependencies": {
     "reveal.js": "4.4.0",
-    "vite": "^4.2.0"
+    "vite": "4.2.1"
   },
   "devDependencies": {
     "cypress": "9.7.0",


### PR DESCRIPTION
- This PR resolves #98.

- The change from `vite` to `vite --host 0.0.0.0` in PR https://github.com/bahmutov/cypress-gh-action-split-jobs/pull/103 did not solve all issues. This PR uses the command `vite --host` (without 0.0.0.0) instead.

- vite is also bumped from `4.2.0` to `4.2.1`
