### PR TITLE
fix: add cypress temporary assets to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules/
 dist
+
+# Cypress temporary assets
+cypress/downloads
+cypress/screenshots
+cypress/videos


### PR DESCRIPTION
This avoids temporary Cypress assets being committed if tests are run locally.